### PR TITLE
v0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drain"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
 edition = "2018"
@@ -14,11 +14,10 @@ A crate that supports graceful shutdown
 retain = ["tower"]
 
 [dependencies]
-futures = { version = "0.3.15", default-features = false }
 tokio = { version = "1", features = ["macros", "sync"] }
 tower = { version = "0.4.7", default-features = false, optional = true }
 
 [dev-dependencies]
-pin-project = "1"
-tokio = { version = "1", features = ["time"] }
+futures = { version = "0.3.15", default-features = false }
+pin-project-lite = "0.2"
 tokio-test = "0.4"


### PR DESCRIPTION
* tests: Use `pin-project-lite`
* tests: Use `tokio_test::task`
* Add `Signal::closed` to wait for all watches to be dropped.