### PR TITLE
chore(deps): update `tower` dependency to v0.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ retain = ["tower"]
 
 [dependencies]
 tokio = { version = "1", features = ["macros", "sync"] }
-tower = { version = "0.4.7", default-features = false, optional = true }
+tower = { version = "0.5.2", default-features = false, optional = true }
 
 [dev-dependencies]
 futures = { version = "0.3.15", default-features = false }


### PR DESCRIPTION
this commit updates the tower dependency from `0.4.7` to `0.5.2`.

see also:
* https://github.com/linkerd/linkerd2/issues/8733
* https://github.com/linkerd/linkerd2-proxy/pull/3504

this allows us to rely upon newer versions of e.g. `axum`, `tonic` without violating `cargo deny`'s duplicate dependency checks.