### PR TITLE
chore: replace tower with tower-layer and tower-service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drain"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
 edition = "2018"
@@ -12,11 +12,12 @@ A crate that supports graceful shutdown
 
 [features]
 default = []
-retain = ["dep:tower"]
+retain = ["dep:tower-layer", "dep:tower-service"]
 
 [dependencies]
 tokio = { version = "1", features = ["macros", "sync"] }
-tower = { version = "0.5.2", default-features = false, optional = true }
+tower-layer = { version = "0.3.3", default-features = false, optional = true }
+tower-service = { version = "0.3.3", default-features = false, optional = true }
 
 [dev-dependencies]
 futures = { version = "0.3.15", default-features = false }

--- a/src/retain.rs
+++ b/src/retain.rs
@@ -4,7 +4,8 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tower::layer::{layer_fn, Layer};
+use tower_layer::{layer_fn, Layer};
+use tower_service::Service;
 
 /// Holds a drain::Watch for as long as a request is pending.
 #[derive(Clone, Debug)]
@@ -25,9 +26,9 @@ impl<S> Retain<S> {
     }
 }
 
-impl<Req, S> tower::Service<Req> for Retain<S>
+impl<Req, S> Service<Req> for Retain<S>
 where
-    S: tower::Service<Req>,
+    S: Service<Req>,
     S::Future: Send + 'static,
 {
     type Response = S::Response;


### PR DESCRIPTION
This eliminates unnecessary API surface area and simplifies the dependency graph.